### PR TITLE
fixing yml path calling

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -129,7 +129,7 @@ workflow {
   if (params.input) {
 
     // Load YAML
-    parameter_yaml = new FileInputStream(new File(params.input))
+    parameter_yaml = file(params.input).readLines().join("\n")
     new Yaml().load(parameter_yaml).each { k, v -> params[k] = v }
 
     // Copy YAML samplesheet to output directory so user has a copy of it


### PR DESCRIPTION
Super small fix to properly load YAML file when using the pipeline with cloud computing environments such as AWS/S3-bucket