### PR TITLE
Avoid `overwrite existing files` error with BUSCO when resuming

### DIFF
--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The tracking for changes started in v2.
 
+## dev
+
+* [#77](https://github.com/fmalmeida/MpGAP/issues/77) - Add cleanup to avoid `overwrite existing files` error in BUSCO when resuming a run.
+
 ## v3.2 -- [2024-Mar-06]
 
 * Update unicyler to v0.5.0

--- a/modules/local/QualityAssessment/quast.nf
+++ b/modules/local/QualityAssessment/quast.nf
@@ -54,6 +54,7 @@ process quast {
   // any case
   """
   # run quast
+  rm -rf ${assembler}/
   quast.py \\
       -o ${assembler} \\
       -t $task.cpus \\
@@ -68,6 +69,7 @@ process quast {
   # run busco
   cp -r /opt/busco_db .
   busco \\
+    -f \\
     --tar \\
     --download_path ./ \\
     -i ${contigs} \\


### PR DESCRIPTION
Relates to #77 